### PR TITLE
Fixed references to encryption/encoding libraries in the SpecRunner

### DIFF
--- a/spec/SpecRunner.html.erb
+++ b/spec/SpecRunner.html.erb
@@ -8,9 +8,9 @@
   <script type="text/javascript" src="infrastructure/jasmine-standalone-1.0.0/lib/jasmine-1.0.0/jasmine-html.js"></script>
   <script type="text/javascript" src="infrastructure/jasmine-jquery-1.3.1.js"></script>
   <script type="text/javascript" src="infrastructure/jquery-1.7.2.min.js"></script>
-  <script type="text/javascript" src="../lib/base64.js"></script>
-  <script type="text/javascript" src="../lib/jsbn.js"></script>
-  <script type="text/javascript" src="../lib/rsa.js"></script>
+  <script type="text/javascript" src="../lib/jsbn/base64.js"></script>
+  <script type="text/javascript" src="../lib/jsbn/jsbn.js"></script>
+  <script type="text/javascript" src="../lib/jsbn/rsa.js"></script>
   <script type="text/javascript" src="infrastructure/jsbn2.js"></script>
   <script type="text/javascript" src="infrastructure/rsa2.js"></script>
 


### PR DESCRIPTION
References to a few libraries in the spec runner were pointing a directory one level too high.
