### PR TITLE
Fix for "Dom Exception 8" causes by submitting an erroneous form 3 times...

### DIFF
--- a/lib/braintree.js
+++ b/lib/braintree.js
@@ -166,6 +166,8 @@ Braintree.EncryptionClient = function (publicKey) {
       for (i = 0; i < hiddenFields.length; i++) {
         form.removeChild(hiddenFields[i]);
       }
+      
+      hiddenFields = [];
     }
 
     for (i = 0; i < inputs.length; i++) {


### PR DESCRIPTION
....

Submitting an erroneous form 3 times causes line 167 to throw a "Dom Exception 8" error. I suspect it's because the the references to the hiddenFields from the previous submission aren't cleared from the `hiddenFields` array once they've been removed from the DOM.
