### PR TITLE
The `findInputs` method is killing IE7

### DIFF
--- a/lib/braintree.js
+++ b/lib/braintree.js
@@ -87,7 +87,7 @@ Braintree.EncryptionClient = function (publicKey) {
 
   var findInputs = function (element) {
     var found = [],
-        children = element.children,
+        children = element.getElementsByTagName('input'),
         child, i;
 
     for (i = 0; i < children.length; i++) {


### PR DESCRIPTION
I've noticed that the `findInputs` method is throwing a fatal error in IE7 when the form it's called on has direct children which aren't `input`s. 

For example: we're using Twitter Bootstrap which calls for the following type of structure...

```
<form class="form-horizontal">
    <div class="control-group">
        <label class="span2 control-label">Card Number</label>

        <div class="preSpan2 controls">
            <input class="span5 cardNumber" type="text" autocomplete="off" data-encrypted-name="number" />
        </div>
    </div>
</form>
```

When you submit the form in IE7 you get `Unable to get value of the property 'data-encrypted-name': object is null or undefined`.
