### PR TITLE
Fix the global variable v leak in the base64 library from jsbn. 

### DIFF
--- a/lib/jsbn/base64.js
+++ b/lib/jsbn/base64.js
@@ -23,10 +23,11 @@ function hex2b64(h) {
 
 // convert a base64 string to hex
 function b64tohex(s) {
-  var ret = ""
+  var ret = "";
   var i;
   var k = 0; // b64 state, 0-3
   var slop;
+  var v;
   for(i = 0; i < s.length; ++i) {
     if(s.charAt(i) == b64pad) break;
     v = b64map.indexOf(s.charAt(i));


### PR DESCRIPTION
Also submitted a pull request on the library itself.
