### PR TITLE
Add support for CommonJS through a umd-like export

### DIFF
--- a/lib/braintree.js
+++ b/lib/braintree.js
@@ -219,4 +219,7 @@ if (typeof define === "function") {
   define("braintree", function () {
     return Braintree;
   });
+} else if (typeof exports === 'object') {
+  module.exports = Braintree;
 }
+


### PR DESCRIPTION
This lets users of tools like [Browserify](http://browserify.org/) and [webpack](http://webpack.github.io/) package braintree-js. When the global issue in #16 is addressed, I imagine a full UMD wrapper can be used.
