### PR TITLE
Add link to braintree-web to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This library is for use with [Braintree's payment gateway](http://braintreepayments.com/) in concert with one of [the supported client libraries](http://braintreepayments.com/docs).  It encrypts sensitive payment information in a web browser using the public key of an asymmetric key pair.
 
+> :grey_exclamation: Notice: `braintree-encryption.js` is an older integration method - [braintree-web](https://github.com/braintree/braintree-web) is the place to go for current integrations and filing issues or PRs.
+
 ## Getting Started
 
 See our <a href="https://www.braintreepayments.com/developers">developer quick start</a> for an example of how to use Braintree.js 


### PR DESCRIPTION
To better guide people looking for where to file issues on the current version of `braintree.js`.